### PR TITLE
curate the homepage model list and rework testimonials

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -209,6 +209,17 @@ h1:not([data-hero-title]), h2, h3, h4, h5, h6 {
 }
 
 /* Typography tweaks for markdown */
+/* Testimonial marquee. Each track renders its cards twice, so shifting it by
+   half its width lands the copy exactly where the original started. */
+@keyframes marquee-left {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
 @layer utilities {
   /* Subtle elevation preset for cards and code blocks, light and dark. */
   .shadow-elevation {
@@ -233,5 +244,43 @@ h1:not([data-hero-title]), h2, h3, h4, h5, h6 {
     -webkit-line-clamp: 2;
     line-clamp: 2;
     overflow: hidden;
+  }
+
+  .marquee-track-left,
+  .marquee-track-right {
+    animation: marquee-left var(--marquee-duration, 60s) linear infinite;
+  }
+
+  .marquee-track-right {
+    animation-direction: reverse;
+  }
+
+  .marquee:hover .marquee-track-left,
+  .marquee:hover .marquee-track-right,
+  .marquee:focus-within .marquee-track-left,
+  .marquee:focus-within .marquee-track-right {
+    animation-play-state: paused;
+  }
+
+  /* Only keyboard focus resets the track, because the focusable copy can be a
+     full sequence width outside the clipped row. Resetting on pointer focus
+     too would move the card out from under the cursor between press and
+     release. The row stays clipped; browsers scroll a hidden container to
+     bring the focused card into view. */
+  .marquee:has(:focus-visible) .marquee-track-left,
+  .marquee:has(:focus-visible) .marquee-track-right {
+    animation: none;
+  }
+
+  /* Without the scroll the row would strand most of its cards off-screen. */
+  @media (prefers-reduced-motion: reduce) {
+    .marquee {
+      overflow-x: auto;
+    }
+
+    .marquee-track-left,
+    .marquee-track-right {
+      animation: none;
+    }
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -221,6 +221,26 @@ h1:not([data-hero-title]), h2, h3, h4, h5, h6 {
 }
 
 @layer utilities {
+  /* Scroll regions on these flat surfaces should not show the stock platform
+     scrollbar. */
+  .scrollbar-subtle {
+    scrollbar-color: var(--border) transparent;
+    scrollbar-width: thin;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar-thumb {
+    background-color: var(--border);
+    border-radius: 9999px;
+  }
+
   /* Subtle elevation preset for cards and code blocks, light and dark. */
   .shadow-elevation {
     box-shadow:

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -316,12 +316,12 @@ export default function Header() {
                 height="14"
                 fill="currentColor"
                 viewBox="0 0 16 16"
-                className="mr-1 text-foreground"
+                className="mr-1 text-foreground transition-[scale,rotate,filter] duration-300 ease-out group-hover/button:scale-125 group-hover/button:-rotate-12 group-hover/button:text-[#e7c46a] group-hover/button:drop-shadow-[0_0_6px_rgba(231,196,106,0.45)]"
               >
                 <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z" />
               </svg>
               Star on github
-              <ArrowUpRight className="h-3 w-3" />
+              <ArrowUpRight className="h-3 w-3 transition-transform duration-300 group-hover/button:translate-x-0.5 group-hover/button:-translate-y-0.5" />
             </a>
           </Button>
           <ThemeToggle />

--- a/components/landing/BrowseModels.tsx
+++ b/components/landing/BrowseModels.tsx
@@ -3,12 +3,15 @@ import Link from "next/link";
 import { usePricingView } from "@/app/contexts/PricingContext";
 import { useModels } from "@/app/contexts/ModelsContext";
 import { getPopularModels } from "@/app/data/models";
-import { useEffect, useState } from "react";
+import { fetchRoutstr21ModelIds } from "@/lib/routstr21";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { CurrencyTabs } from "@/components/ui/currency-tabs";
 import {
   formatCompactContextLength,
   formatCompactPriceValue,
+  formatSatsPriceValue,
 } from "@/lib/number-format";
 
 interface DisplayModel {
@@ -20,147 +23,198 @@ interface DisplayModel {
   created: number;
 }
 
+// A provider publishing placeholder metadata should not be able to set the
+// price shown for a model, so take the median across everyone serving it.
+function median(values: number[]): number {
+  const sorted = values.filter((n) => Number.isFinite(n) && n > 0).sort((a, b) => a - b);
+  if (sorted.length === 0) return 0;
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[middle]
+    : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+const FALLBACK_MODEL_COUNT = 6;
+
 export function LandingBrowseModels() {
   const { currency } = usePricingView();
-  const priceUnit = currency === "sats" ? "sats/1M tokens" : "USD/1M tokens";
-  const { models, loading: modelsLoading } = useModels();
-  const [displayModels, setDisplayModels] = useState<DisplayModel[]>([]);
+  const priceAmount = (value: string) =>
+    currency === "usd" ? `$${value}` : `${value} sats`;
+  const { models, modelProviderEntries, loading: modelsLoading } = useModels();
+  const [curatedIds, setCuratedIds] = useState<string[] | null>(null);
 
   useEffect(() => {
-    const current = getPopularModels(6, models);
+    let cancelled = false;
+    fetchRoutstr21ModelIds().then((ids) => {
+      if (!cancelled) setCuratedIds(ids);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-    if (!current || current.length === 0) {
-      setDisplayModels([]);
-      return;
-    }
+  const curatedModels = useMemo(
+    () =>
+      (curatedIds ?? [])
+        .map((id) => models.find((model) => model.id === id))
+        .filter((model): model is NonNullable<typeof model> => Boolean(model)),
+    [curatedIds, models]
+  );
+  const isCurated = curatedModels.length > 0;
 
-    const formattedModels = current.map((model) => {
-      const modelName =
-        model.name.split("/").length > 1
-          ? model.name.split("/")[1]
-          : model.name;
+  const displayModels: DisplayModel[] = useMemo(() => {
+    if (models.length === 0) return [];
+
+    const selected = isCurated
+      ? curatedModels
+      : getPopularModels(FALLBACK_MODEL_COUNT, models);
+
+    return selected.map((model) => {
+      const entries = modelProviderEntries.get(model.id);
+      const variants = entries && entries.length > 0 ? entries.map((entry) => entry.model) : [model];
 
       const promptPrice =
-        currency === "sats"
-          ? model.sats_pricing.prompt > 0
-            ? model.sats_pricing.prompt * 1_000_000
-            : 0
-          : model.pricing.prompt * 1_000_000;
+        median(
+          variants.map((variant) =>
+            currency === "sats"
+              ? variant.sats_pricing?.prompt ?? 0
+              : variant.pricing?.prompt ?? 0
+          )
+        ) * 1_000_000;
       const completionPrice =
-        currency === "sats"
-          ? model.sats_pricing.completion > 0
-            ? model.sats_pricing.completion * 1_000_000
-            : 0
-          : model.pricing.completion * 1_000_000;
+        median(
+          variants.map((variant) =>
+            currency === "sats"
+              ? variant.sats_pricing?.completion ?? 0
+              : variant.pricing?.completion ?? 0
+          )
+        ) * 1_000_000;
+      const contextLength = median(variants.map((variant) => variant.context_length ?? 0));
+
+      const modelName =
+        model.name.split("/").length > 1 ? model.name.split("/")[1] : model.name;
 
       return {
         id: model.id,
         name: modelName,
-        promptPrice: formatCompactPriceValue(promptPrice, {
-          fixedSmallDecimals: currency === "usd",
-        }),
-        completionPrice: formatCompactPriceValue(completionPrice, {
-          fixedSmallDecimals: currency === "usd",
-        }),
-        context: model.context_length
-          ? formatCompactContextLength(model.context_length)
-          : "N/A",
+        promptPrice:
+          currency === "sats"
+            ? formatSatsPriceValue(promptPrice)
+            : formatCompactPriceValue(promptPrice, { fixedSmallDecimals: true }),
+        completionPrice:
+          currency === "sats"
+            ? formatSatsPriceValue(completionPrice)
+            : formatCompactPriceValue(completionPrice, { fixedSmallDecimals: true }),
+        context: contextLength ? formatCompactContextLength(contextLength) : "N/A",
         created: model.created,
       };
     });
-    setDisplayModels(formattedModels);
-  }, [currency, models]);
+  }, [curatedModels, isCurated, models, modelProviderEntries, currency]);
 
   return (
     <div className="w-full relative md:flex md:min-h-[calc(100svh-80px)] md:flex-col md:justify-center">
       <div className="w-full px-[clamp(1rem,5vw,5rem)] py-20 max-w-[1800px] mx-auto">
         <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-12">
           <div>
+            {isCurated && (
+              <p className="mb-2 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                Routstr 21
+              </p>
+            )}
             <h2 className="text-xl font-bold text-foreground mb-2">
               Browse Models
             </h2>
             <p className="text-muted-foreground text-sm max-w-xl">
-              Access leading AI models through independent providers.
+              Recommended models, priced across independent providers.
             </p>
           </div>
-          <Button asChild className="hidden md:inline-flex">
-            <Link href="/models">
-              View all models
-              <ArrowRight className="h-3 w-3" aria-hidden="true" />
-            </Link>
-          </Button>
+          <div className="flex items-center gap-3">
+            <CurrencyTabs />
+            <Button asChild className="hidden md:inline-flex">
+              <Link href="/models">
+                View all models
+                <ArrowRight className="h-3 w-3" aria-hidden="true" />
+              </Link>
+            </Button>
+          </div>
         </div>
 
-        <div className="flex flex-col mt-8">
-          <div className="grid grid-cols-12 gap-4 py-3 border-b border-border bg-card/50 px-4 text-[10px] font-bold text-muted-foreground">
-            <div className="col-span-6 md:col-span-6 lg:col-span-6">Model</div>
-            <div className="hidden lg:block col-span-2">Context</div>
-            <div className="hidden md:block col-span-2">Added</div>
-            <div className="col-span-6 md:col-span-4 lg:col-span-2 text-right">Pricing (in/out)</div>
-          </div>
-
-          {modelsLoading ? (
-            [...Array(6)].map((_, index) => (
-              <div
-                key={index}
-                className="grid grid-cols-12 gap-4 py-6 border-b border-border/30 px-4 animate-pulse"
-              >
-                <div className="col-span-6 md:col-span-6 lg:col-span-6 flex items-center">
-                  <div className="h-4 bg-border rounded w-3/4" />
-                </div>
-                <div className="hidden lg:block col-span-2 flex items-center">
-                  <div className="h-3 bg-border rounded w-1/2" />
-                </div>
-                <div className="hidden md:block col-span-2 flex items-center">
-                  <div className="h-3 bg-border rounded w-1/2" />
-                </div>
-                <div className="col-span-6 md:col-span-4 lg:col-span-2 flex flex-col justify-center items-end gap-2">
-                  <div className="h-3 bg-border rounded w-16" />
-                  <div className="h-3 bg-border rounded w-16" />
-                </div>
-              </div>
-            ))
-          ) : displayModels.length > 0 ? (
-            displayModels.map((model) => (
-              <Link
-                key={model.id}
-                href={`/models/${model.id}`}
-                className="grid grid-cols-12 gap-4 py-5 border-b border-border/30 px-4 hover:bg-card transition-colors group"
-              >
-                <div className="col-span-6 md:col-span-6 lg:col-span-6 flex items-center">
-                  <span className="font-bold text-sm text-foreground group-hover:underline decoration-muted-foreground underline-offset-4 truncate">
-                    {model.name}
-                  </span>
-                </div>
-                <div className="hidden lg:flex col-span-2 items-center text-xs text-muted-foreground font-mono">
-                  {model.context}
-                </div>
-                <div className="hidden md:flex col-span-2 items-center text-xs text-muted-foreground">
-                  {new Date(model.created * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
-                </div>
-                <div className="col-span-6 md:col-span-4 lg:col-span-2 text-right text-[10px] flex flex-col justify-center gap-1">
-                  <div className="flex items-center justify-end gap-1.5">
-                    <span className="text-muted-foreground font-medium">in</span>
-                    <span className="text-foreground font-mono">
-                      {model.promptPrice}
-                    </span>
-                    <span className="text-[9px] text-muted-foreground whitespace-nowrap">{priceUnit}</span>
-                  </div>
-                  <div className="flex items-center justify-end gap-1.5">
-                    <span className="text-muted-foreground font-medium">out</span>
-                    <span className="text-foreground font-mono">
-                      {model.completionPrice}
-                    </span>
-                    <span className="text-[9px] text-muted-foreground whitespace-nowrap">{priceUnit}</span>
-                  </div>
-                </div>
-              </Link>
-            ))
-          ) : (
-            <div className="text-center py-12">
-              <p className="text-xs text-muted-foreground">No models available at the moment.</p>
+        <div className="relative mt-8">
+          <div className="scrollbar-subtle flex max-h-[19rem] flex-col overflow-y-auto">
+            <div className="sticky top-0 z-10 grid grid-cols-12 gap-4 py-3 border-b border-border bg-background px-4 text-[10px] font-bold text-muted-foreground">
+              <div className="col-span-6 md:col-span-6 lg:col-span-6">Model</div>
+              <div className="hidden lg:block col-span-2">Context</div>
+              <div className="hidden md:block col-span-2">Added</div>
+              <div className="col-span-6 md:col-span-4 lg:col-span-2 text-right">Pricing (in/out)</div>
             </div>
-          )}
+
+            {modelsLoading ? (
+              [...Array(6)].map((_, index) => (
+                <div
+                  key={index}
+                  className="grid grid-cols-12 gap-4 py-6 border-b border-border/30 px-4 animate-pulse"
+                >
+                  <div className="col-span-6 md:col-span-6 lg:col-span-6 flex items-center">
+                    <div className="h-4 bg-border rounded w-3/4" />
+                  </div>
+                  <div className="hidden lg:block col-span-2 flex items-center">
+                    <div className="h-3 bg-border rounded w-1/2" />
+                  </div>
+                  <div className="hidden md:block col-span-2 flex items-center">
+                    <div className="h-3 bg-border rounded w-1/2" />
+                  </div>
+                  <div className="col-span-6 md:col-span-4 lg:col-span-2 flex flex-col justify-center items-end gap-2">
+                    <div className="h-3 bg-border rounded w-16" />
+                    <div className="h-3 bg-border rounded w-16" />
+                  </div>
+                </div>
+              ))
+            ) : displayModels.length > 0 ? (
+              displayModels.map((model) => (
+                <Link
+                  key={model.id}
+                  href={`/models/${model.id}`}
+                  className="grid grid-cols-12 gap-4 py-5 border-b border-border/30 px-4 hover:bg-card transition-colors group"
+                >
+                  <div className="col-span-6 md:col-span-6 lg:col-span-6 flex items-center">
+                    <span className="font-bold text-sm text-foreground group-hover:underline decoration-muted-foreground underline-offset-4 truncate">
+                      {model.name}
+                    </span>
+                  </div>
+                  <div className="hidden lg:flex col-span-2 items-center text-xs text-muted-foreground font-mono">
+                    {model.context}
+                  </div>
+                  <div className="hidden md:flex col-span-2 items-center text-xs text-muted-foreground">
+                    {new Date(model.created * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                  </div>
+                  <div className="col-span-6 md:col-span-4 lg:col-span-2 text-right text-[10px] flex flex-col justify-center gap-1">
+                    <div className="flex items-center justify-end gap-1.5">
+                      <span className="text-muted-foreground font-medium">in</span>
+                      <span className="text-foreground font-mono whitespace-nowrap">
+                        {priceAmount(model.promptPrice)}
+                        <span className="text-[9px] font-normal text-muted-foreground">/M tokens</span>
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-end gap-1.5">
+                      <span className="text-muted-foreground font-medium">out</span>
+                      <span className="text-foreground font-mono whitespace-nowrap">
+                        {priceAmount(model.completionPrice)}
+                        <span className="text-[9px] font-normal text-muted-foreground">/M tokens</span>
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              ))
+            ) : (
+              <div className="text-center py-12">
+                <p className="text-xs text-muted-foreground">No models available at the moment.</p>
+              </div>
+            )}
+          </div>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent"
+          />
         </div>
 
         <div className="mt-8 md:hidden">

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { ArrowLeft, ArrowRight, ArrowUpRight } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Image from "next/image";
 import Link from "next/link";
@@ -13,7 +12,6 @@ interface Testimonial {
   handle: string;
   url: string;
   platform?: "x" | "nostr";
-  image?: string;
 }
 
 // Featured testimonial (Jack) leads the rotation
@@ -34,8 +32,6 @@ const testimonials: Testimonial[] = [
     src: "https://image.nostr.build/338193e0b573539b3658205e7aa6810879857b431afff864ff3229421835c867.jpg",
     url: "https://nostr.eu/nevent1qqs24ymyjlp730qgf2nrj7utk3kf8m08xsrmftxdk5d60ln92tgsvvqzyrkmgup8z2t6cknp7fml8ng5me2vvl44enfqauxemu5muxrgtwcqgx6yq3l",
     platform: "nostr",
-    image:
-      "https://image.nostr.build/34d84344a679f3cd9b6a9cc18b354e5eb38bb2c4d2f1c9791f969b19029b546f.png",
   },
   {
     name: "calle",
@@ -212,141 +208,156 @@ const testimonials: Testimonial[] = [
   },
 ];
 
-const AUTO_ADVANCE_MS = 6500;
+function PlatformIcon({ platform }: { platform?: "x" | "nostr" }) {
+  if (platform === "nostr") {
+    // Nostr ostrich mark by SatsCoffee (github.com/satscoffee/nostr_icons).
+    return (
+      <svg viewBox="0 0 875 875" className="h-3.5 w-3.5 fill-current" aria-hidden="true">
+        <path d="m684.72,485.57c.22,12.59-11.93,51.47-38.67,81.3-26.74,29.83-56.02,20.85-58.42,20.16s-3.09-4.46-7.89-3.77-9.6,6.17-18.86,7.2-17.49,1.71-26.06-1.37c-4.46.69-5.14.71-7.2,2.24s-17.83,10.79-21.6,11.47c0,7.2-1.37,44.57,0,55.89s3.77,25.71,7.54,36c3.77,10.29,2.74,10.63,7.54,9.94s13.37.34,15.77,4.11c2.4,3.77,1.37,6.51,5.49,8.23s60.69,17.14,99.43,19.2c26.74.69,42.86,2.74,52.12,19.54,1.37,7.89,7.54,13.03,11.31,14.06s8.23,2.06,12,5.83,1.03,8.23,5.49,11.66c4.46,3.43,14.74,8.57,25.37,13.71,10.63,5.14,15.09,13.37,15.77,16.11s1.71,10.97,1.71,10.97c0,0-8.91,0-10.97-2.06s-2.74-5.83-2.74-5.83c0,0-6.17,1.03-7.54,3.43s.69,2.74-7.89.69-11.66-3.77-18.17-8.57c-6.51-4.8-16.46-17.14-25.03-16.8,4.11,8.23,5.83,8.23,10.63,10.97s8.23,5.83,8.23,5.83l-7.2,4.46s-4.46,2.06-14.74-.69-11.66-4.46-12.69-10.63,0-9.26-2.74-14.4-4.11-15.77-22.29-21.26c-18.17-5.49-66.52-21.26-100.12-24.69s-22.63-2.74-28.11-1.37-15.77,4.46-26.4-1.37c-10.63-5.83-16.8-13.71-17.49-20.23s-1.71-10.97,0-19.2,3.43-19.89,1.71-26.74-14.06-55.89-19.89-64.12c-13.03,1.03-50.74-.69-50.74-.69,0,0-2.4-.69-17.49,5.83s-36.48,13.76-46.77,19.93-14.4,9.7-16.12,13.13c.12,3-1.23,7.72-2.79,9.06s-12.48,2.42-12.48,2.42c0,0-5.85,5.86-8.25,9.97-6.86,9.6-55.2,125.14-66.52,149.83-13.54,32.57-9.77,27.43-37.71,27.43s-8.06.3-8.06.3c0,0-12.34,5.88-16.8,5.88s-18.86-2.4-26.4,0-16.46,9.26-23.31,10.29-4.95-1.34-8.38-3.74c-4-.21-14.27-.12-14.27-.12,0,0,1.74-6.51,7.91-10.88,8.23-5.83,25.37-16.11,34.63-21.26s17.49-7.89,23.31-9.26,18.51-6.17,30.51-9.94,19.54-8.23,29.83-31.54c10.29-23.31,50.4-111.43,51.43-116.23.63-2.96,3.73-6.48,4.8-15.09.66-5.35-2.49-13.04,1.71-22.63,10.97-25.03,21.6-20.23,26.4-20.23s17.14.34,26.4-1.37,15.43-2.74,24.69-7.89,11.31-8.91,11.31-8.91l-19.89-3.43s-18.51.69-25.03-4.46-15.43-15.77-15.43-15.77l-7.54-7.2,1.03,8.57s-5.14-8.91-6.51-10.29-8.57-6.51-11.31-11.31-7.54-25.03-7.54-25.03l-6.17,13.03-1.71-18.86-5.14,7.2-2.74-16.11-4.8,8.23-3.43-14.4-5.83,4.46-2.4-10.29-5.83-3.43s-14.06-9.26-16.46-9.6-4.46,3.43-4.46,3.43l1.37,12-12.2-6.27-7-11.9s2.36,4.01-9.62,7.53c-20.55,0-21.89-2.28-24.93-3.94-1.31-6.56-5.57-10.11-5.57-10.11h-20.57l-.34-6.86-7.89,3.09.69-10.29h-14.06l1.03-11.31h-8.91s3.09-9.26,25.71-22.97,25.03-16.46,46.29-17.14c21.26-.69,32.91,2.74,46.29,8.23s38.74,13.71,43.89,17.49c11.31-9.94,28.46-19.89,34.29-19.89,1.03-2.4,6.19-12.33,17.96-17.6,35.31-15.81,108.13-34,131.53-35.54,31.2-2.06,7.89-1.37,39.09,2.06,31.2,3.43,54.17,7.54,69.6,12.69,12.58,4.19,25.03,9.6,34.29,2.06,4.33-1.81,11.81-1.34,17.83-5.14,30.69-25.09,34.72-32.35,43.63-41.95s20.14-24.91,22.54-45.14,4.46-58.29-10.63-88.12-28.8-45.26-34.63-69.26c-5.83-24-8.23-61.03-6.17-73.03,2.06-12,5.14-22.29,6.86-30.51s9.94-14.74,19.89-16.46c9.94-1.71,17.83,1.37,22.29,4.8,4.46,3.43,11.65,6.28,13.37,10.29.34,1.71-1.37,6.51,8.23,8.23,9.6,1.71,16.05,4.16,16.05,4.16,0,0,15.64,4.29,3.11,7.73-12.69,2.06-20.52-.71-24.29,1.69s-7.21,10.08-9.61,11.1-7.2.34-12,4.11-9.6,6.86-12.69,14.4-5.49,15.77-3.43,26.74,8.57,31.54,14.4,43.2c5.83,11.66,20.23,40.8,24.34,47.66s15.77,29.49,16.8,53.83,1.03,44.23,0,54.86-10.84,51.65-35.53,85.94c-8.16,14.14-23.21,31.9-24.67,35.03-1.45,3.13-3.02,4.88-1.61,7.65,4.62,9.05,12.87,22.13,14.71,29.22,2.29,6.64,6.99,16.13,7.22,28.72Z" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 24 24" className="h-3 w-3 fill-current" aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+// The right margin, rather than a flex gap, keeps each card the same width as
+// its trailing space so a -50% shift on the duplicated track loops seamlessly.
+function MarqueeCard({
+  testimonial,
+  duplicate = false,
+}: {
+  testimonial: Testimonial;
+  duplicate?: boolean;
+}) {
+  return (
+    <Link
+      href={testimonial.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-hidden={duplicate || undefined}
+      tabIndex={duplicate ? -1 : undefined}
+      className="group mr-5 flex w-[300px] shrink-0 flex-col justify-between rounded-2xl border border-border bg-card p-5 hover:border-foreground/20 sm:w-[340px]"
+    >
+      <div className="line-clamp-5 text-xs leading-relaxed text-muted-foreground break-words [overflow-wrap:anywhere] md:text-sm">
+        {testimonial.quote}
+      </div>
+      <div className="mt-5 flex min-w-0 items-center gap-3 border-t border-border pt-4">
+        <Image
+          src={testimonial.src}
+          alt=""
+          width={30}
+          height={30}
+          className="h-[30px] w-[30px] shrink-0 rounded-full object-cover"
+          loading="lazy"
+          unoptimized={testimonial.src.endsWith(".gif")}
+        />
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate text-xs font-bold text-foreground">
+            {testimonial.name}
+          </span>
+          <span className="truncate text-[10px] text-muted-foreground">
+            {testimonial.handle}
+          </span>
+        </div>
+        <span className="ml-auto shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground">
+          <PlatformIcon platform={testimonial.platform} />
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+function MarqueeRow({
+  items,
+  direction,
+  duration,
+}: {
+  items: Testimonial[];
+  direction: "left" | "right";
+  duration: string;
+}) {
+  return (
+    <div className="marquee overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]">
+      <div
+        className={cn(
+          "flex w-max items-stretch py-1",
+          direction === "left" ? "marquee-track-left" : "marquee-track-right"
+        )}
+        style={{ "--marquee-duration": duration } as React.CSSProperties}
+      >
+        {items.map((testimonial, index) => (
+          <MarqueeCard key={`a-${index}`} testimonial={testimonial} />
+        ))}
+        {items.map((testimonial, index) => (
+          <MarqueeCard key={`b-${index}`} testimonial={testimonial} duplicate />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export function LandingTestimonials() {
-  const spotlight = [featuredTestimonial, ...testimonials];
-  const [active, setActive] = useState(0);
-  const [paused, setPaused] = useState(false);
-
-  useEffect(() => {
-    if (paused) return;
-    const timer = window.setInterval(
-      () => setActive((current) => (current + 1) % spotlight.length),
-      AUTO_ADVANCE_MS
-    );
-    return () => window.clearInterval(timer);
-  }, [paused, spotlight.length]);
-
-  const current = spotlight[active];
-  const move = (direction: 1 | -1) =>
-    setActive((now) => (now + direction + spotlight.length) % spotlight.length);
+  const [rowOne, rowTwo] = [testimonials.slice(0, 5), testimonials.slice(5)];
 
   return (
-    <div className="w-full px-[clamp(1rem,5vw,5rem)] py-20 max-w-[1800px] mx-auto relative md:flex md:min-h-[calc(100svh-80px)] md:flex-col md:justify-center">
-      <div className="grid items-center gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] lg:gap-16">
-        <div>
-          <p className="mb-2 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
-            Community
-          </p>
-          <h2 className="text-xl font-bold text-foreground mb-2">
-            What people are saying
-          </h2>
-          <p className="text-muted-foreground text-sm max-w-xl">
-            Join the growing community embracing privacy-first AI access
-          </p>
+    <div className="w-full relative py-20 md:flex md:min-h-[calc(100svh-80px)] md:flex-col md:justify-center">
+      <div className="mx-auto w-full max-w-[1800px] px-[clamp(1rem,5vw,5rem)]">
+        <p className="mb-2 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          Community
+        </p>
+        <h2 className="mb-2 text-xl font-bold text-foreground">
+          What people are saying
+        </h2>
+        <p className="max-w-xl text-sm text-muted-foreground">
+          Join the growing community embracing privacy-first AI access
+        </p>
 
-          <div className="mt-8 flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              onClick={() => move(-1)}
-              aria-label="Previous testimonial"
-              className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-background text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
-            >
-              <ArrowLeft className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              onClick={() => move(1)}
-              aria-label="Next testimonial"
-              className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-background text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
-            >
-              <ArrowRight className="h-4 w-4" />
-            </button>
-
-            <div className="ml-1 flex items-center gap-2">
-              {spotlight.map((_, index) => (
-                <button
-                  key={index}
-                  type="button"
-                  onClick={() => setActive(index)}
-                  aria-label={`Show testimonial ${index + 1} of ${spotlight.length}`}
-                  className={cn(
-                    "h-1.5 rounded-full transition-all",
-                    index === active
-                      ? "w-8 bg-foreground"
-                      : "w-1.5 bg-border hover:bg-muted-foreground/40"
-                  )}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-
-        <div
-          onMouseEnter={() => setPaused(true)}
-          onMouseLeave={() => setPaused(false)}
-          onFocus={() => setPaused(true)}
-          onBlur={() => setPaused(false)}
+        <Link
+          href={featuredTestimonial.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group relative mx-auto mt-12 block w-full max-w-2xl overflow-hidden rounded-2xl border border-border bg-card p-8 text-center hover:border-foreground/20 md:p-10"
         >
-          <Link
-            key={active}
-            href={current.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group relative block animate-in fade-in slide-in-from-bottom-2 overflow-hidden rounded-2xl border border-border bg-card p-7 duration-500 transition-colors hover:border-foreground/20 md:p-10"
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute -top-7 left-5 select-none font-mono text-[7rem] leading-none text-foreground/[0.05]"
           >
-            <span
-              aria-hidden="true"
-              className="pointer-events-none absolute -top-7 left-5 select-none font-mono text-[7rem] leading-none text-foreground/[0.05]"
-            >
-              &ldquo;
-            </span>
-
-            <div className="relative">
-              <div className="mb-6 text-xs leading-relaxed text-muted-foreground break-words [overflow-wrap:anywhere] md:text-sm [&_pre]:max-w-full [&_pre]:overflow-x-auto">
-                {current.quote}
-              </div>
-
-              {current.image && (
-                <div className="mt-4 max-w-[300px] overflow-hidden rounded-xl border border-border md:max-w-[340px]">
-                  <Image
-                    src={current.image}
-                    alt="Attached image"
-                    width={500}
-                    height={300}
-                    className="h-auto w-full opacity-80"
-                    loading="lazy"
-                  />
-                </div>
-              )}
-
-              <div className="mt-8 flex items-center justify-between gap-4">
-                <div className="flex min-w-0 items-center gap-3">
-                  <Image
-                    src={current.src}
-                    alt={current.name}
-                    width={40}
-                    height={40}
-                    className="h-10 w-10 rounded-full object-cover"
-                    loading="lazy"
-                    unoptimized={current.src.endsWith(".gif")}
-                  />
-                  <div className="flex min-w-0 flex-col">
-                    <span className="truncate text-xs font-bold text-foreground">
-                      {current.name}
-                    </span>
-                    <span className="truncate text-[10px] text-muted-foreground">
-                      {current.handle}
-                    </span>
-                  </div>
-                </div>
-                <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground" />
-              </div>
+            &ldquo;
+          </span>
+          <p className="relative text-xl font-bold tracking-tight text-foreground md:text-2xl">
+            {featuredTestimonial.quote}
+          </p>
+          <div className="relative mt-6 flex items-center justify-center gap-3">
+            <Image
+              src={featuredTestimonial.src}
+              alt=""
+              width={36}
+              height={36}
+              className="h-9 w-9 rounded-full object-cover"
+              loading="lazy"
+            />
+            <div className="flex flex-col text-left">
+              <span className="text-xs font-bold text-foreground">
+                {featuredTestimonial.name}
+              </span>
+              <span className="text-[10px] text-muted-foreground">
+                {featuredTestimonial.handle}
+              </span>
             </div>
-          </Link>
-        </div>
+            <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground" />
+          </div>
+        </Link>
       </div>
+
+      <div className="mt-12 flex flex-col gap-5">
+        <MarqueeRow items={rowOne} direction="left" duration="60s" />
+        <MarqueeRow items={rowTwo} direction="right" duration="75s" />
+      </div>
+
       <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-border to-transparent" />
     </div>
   );

--- a/components/ui/currency-tabs.tsx
+++ b/components/ui/currency-tabs.tsx
@@ -18,10 +18,10 @@ export function CurrencyTabs({ className = '' }: CurrencyTabsProps) {
       className={cn('w-auto', className)}
     >
       <TabsList variant="line" className="h-8">
-        <TabsTrigger value="sats" className="h-7 text-xs">
+        <TabsTrigger value="sats" className="h-7 text-xs transition-none">
           sats
         </TabsTrigger>
-        <TabsTrigger value="usd" className="h-7 text-xs">
+        <TabsTrigger value="usd" className="h-7 text-xs transition-none">
           usd
         </TabsTrigger>
       </TabsList>

--- a/lib/number-format.ts
+++ b/lib/number-format.ts
@@ -87,3 +87,11 @@ export function formatCompactPriceValue(
     compactMaximumFractionDigits: 1,
   });
 }
+
+// Sats are whole units, so compacting them to "2.6K" implies a precision that
+// does not exist and, worse, makes 79 and 65,881 occupy the same width in a
+// column. Plain integers keep one format across the whole range.
+export function formatSatsPriceValue(value: number): string {
+  if (!Number.isFinite(value)) return "0";
+  return getFormatter("standard", 0, 0).format(value);
+}

--- a/lib/routstr21.ts
+++ b/lib/routstr21.ts
@@ -1,0 +1,45 @@
+import { createPool, getDefaultRelays } from "@/lib/nostr";
+
+// Routstr publishes its curated model list as a replaceable event. This is the
+// same list the chat app's model selector reads, so both stay in step.
+const ROUTSTR_PUBKEY =
+  "4ad6fa2d16e2a9b576c863b4cf7404a70d4dc320c0c447d10ad6ff58993eacc8";
+const LIST_KIND = 38423;
+const LIST_IDENTIFIER = "routstr-21-models";
+const QUERY_TIMEOUT_MS = 5000;
+
+const RELAYS = Array.from(
+  new Set([...getDefaultRelays(), "wss://relay.routstr.com"])
+);
+
+export async function fetchRoutstr21ModelIds(): Promise<string[]> {
+  const pool = createPool();
+  try {
+    const events = await pool.querySync(
+      RELAYS,
+      {
+        kinds: [LIST_KIND],
+        "#d": [LIST_IDENTIFIER],
+        authors: [ROUTSTR_PUBKEY],
+      },
+      { maxWait: QUERY_TIMEOUT_MS }
+    );
+
+    // NIP-01 addressable-event rule: newest wins, ties to lower id. Relays can
+    // still be holding an older revision of the list.
+    const [event] = events.sort(
+      (a, b) => b.created_at - a.created_at || (a.id < b.id ? -1 : 1)
+    );
+    if (!event) return [];
+
+    const content = JSON.parse(event.content) as { models?: unknown };
+    if (!Array.isArray(content.models)) return [];
+    return content.models.filter(
+      (id): id is string => typeof id === "string" && id.length > 0
+    );
+  } catch {
+    return [];
+  } finally {
+    pool.close(RELAYS);
+  }
+}


### PR DESCRIPTION
Preview: https://29380tojcqwoksuar2gg4xpowomw1up2ftvhvuhatveib1bttkpr-a1abdfd0.nsite.lol/

The model table was showing one node's placeholder data, every row at 4096 context and a flat 1.285 sats/1M for both in and out. `getPopularModels` sorts by `created` despite the name, so whoever registered last owned the whole table. It now pulls the Routstr 21 list (kind 38423, same event the chat selector reads) and takes the median price across providers, so one node can't set what everyone sees. Capped to a few rows with the rest scrollable, and wired up `CurrencyTabs`, which was already in the repo but never imported anywhere.

Testimonials were a one-at-a-time carousel, so 12 of the 13 quotes never got seen. Now a featured quote plus two scrolling rows. Same quotes, nothing rewritten.

Star in the header animates on hover.

Checked on a prod build in light and dark. Verified the medians against live provider data for a few models, contexts match exactly. Marquee loop is seamless and tab order skips the duplicated cards.

One gap: the marquee only pauses on hover and focus, so there's no on-page pause for touch. Anyone with reduced motion set gets the static version.