### PR TITLE
read stats from a relay that accepts large provider reports

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -131,8 +131,15 @@ const ANALYTICS_SCHEMAS = new Set([
   "routstr.analytics.usage.v2",
   "routstr.analytics.snapshot.v1",
 ]);
+// relay.ditto.pub accepts 4 MB events, so it holds provider reports that the
+// 128 KiB relays reject outright. Stats only, other features do not need it.
 const RELAYS = Array.from(
-  new Set([...getDefaultRelays(), "wss://relay.routstr.com", "wss://nos.lol"]),
+  new Set([
+    ...getDefaultRelays(),
+    "wss://relay.routstr.com",
+    "wss://nos.lol",
+    "wss://relay.ditto.pub",
+  ]),
 );
 
 const WINDOW_OPTIONS: Array<{ id: WindowKey; label: string }> = [

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1377,11 +1377,20 @@ async function fetchStatsSnapshotsWithFallback(
     const liveData = await fetchStatsSnapshots(cachedCoords, signal);
     const mergedCoords = await updateStatsCache(liveData.coords);
     const timelines = buildTimelinesFromCoords(Object.values(mergedCoords));
+    // Only a delivered event proves a relay replied. nostr-tools fires a
+    // synthetic EOSE after 4.4s, so an open socket proves nothing.
+    const anyRelayDelivered = Object.values(liveData.relayStatuses).some(
+      (relay) => relay.state === "active" || relay.state === "done",
+    );
     return {
       relayStatuses: liveData.relayStatuses,
       timelines,
       emptyMessage:
-        timelines.length === 0 ? "No analytics snapshots found yet." : null,
+        timelines.length > 0
+          ? null
+          : anyRelayDelivered
+            ? "No analytics snapshots found yet."
+            : "No relay returned analytics stats. Retrying shortly.",
     };
   } catch (error) {
     if (isAbortError(error)) throw error;

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -118,7 +118,6 @@ export const getDefaultRelays = (): string[] => {
   return [
     'wss://relay.damus.io',
     'wss://relay.nostr.band',
-    'wss://nos.lol',
-    'wss://nostr.mutinywallet.com'
+    'wss://nos.lol'
   ];
 }; 


### PR DESCRIPTION
Providers disappear from the stats page and come back on the next load. The page shows a confident count either way, so a load that lost a third of the network looks exactly like one that did not.

## Why

Two relays in the stats pool cap incoming messages at 131,072 bytes, and provider reports have outgrown that. Two are over it today and two more are close:

```
relay caps            nos.lol                   131,072
                      relay.routstr.com         131,072
                      relay.damus.io          1,000,000

report sizes          routstr.otrta.me          240,953   1.84x over
                      api.nonkycai.com          152,017   1.16x over
                      llm.satsandsports.cash    114,249   87% of cap
                      privateprovider.xyz        89,039   68% of cap
```

A report the capped relays refuse is stored nowhere except damus, so that provider is only ever as visible as damus is. Over one day damus went from returning the largest of those reports on 4 of 10 attempts to 0 of 6, and the live site's console was logging the websocket failure while that happened.

`nostr.mutinywallet.com` compounds it from the other side. It has no DNS record at all, so every relay round spends part of its 9 second budget waiting on a host that cannot resolve. It sits in `getDefaultRelays()`, which seven files call.

## What changed

`relay.ditto.pub` joins the stats relay set. It accepts 4 MB messages, so the oversized reports are storable there, and it returned the largest of them on 6 of 6 attempts with a copy 31 hours newer than damus last served. Stats only, not `getDefaultRelays()`, since the globe and the reviews do not need a full analytics archive. `nostr.mutinywallet.com` is removed. The pool stays at five.

The empty state stops overstating what we know. It read "No analytics snapshots found yet." beside a Providers count of 0, which is a claim about the network when the truth was that nothing answered. It now separates the two, and the test is `state === "active" || "done"` rather than anything connection based, because nostr-tools fires a synthetic EOSE 4.4 seconds after subscribing whether or not the relay ever replied, so an open socket that ignores the request would otherwise have counted as an answer.

## How tested

Production build and lint. The page's own fetch run five times per pool, interleaved so both saw the same network:

```
                             before              after
providers per run            28 30 21 21 0       21 38 36 38 21
median providers             21                  36
largest report present       1 of 5              3 of 5
union across runs            36                  39
```

Three providers appear only with the new pool and none are lost. The zero in the old runs is the blank page this fixes.

For the removal, all seven callers of `getDefaultRelays()` were walked. Nothing loses a usable event source, since the host does not resolve, and the publish path stops counting that guaranteed connection failure as a success in its `Promise.any`.

This makes thin loads rarer, not gone. Two of the five new runs still came back with 21 providers, and the browser still does the relay round itself on a 9 second budget. Nothing here stops reports outgrowing relay limits either, which is the upstream cause and belongs where they are published.